### PR TITLE
Añade botón para habilitar/deshabilitar geolocalización

### DIFF
--- a/apps/web/priv/static/css/app.css
+++ b/apps/web/priv/static/css/app.css
@@ -705,15 +705,29 @@ form.link, form.button {
     border-bottom: 0;
   }
 }
-
 body {
-  background-color: #b5d0d0;
-  margin: 0;
-  padding: 0;
+    background-color: #b5d0d0;
+    margin: 0;
+    padding: 0;
 }
 
 #map {
-  height: 100vh;
+    height: 100vh;
+}
+
+.left-panel {
+    width: 200px;
+    height: 100vh;
+    float: left;
+    border-right: solid 2px #b29ac3;
+}
+
+.geolocation {
+    margin-top: 1em;
+}
+
+.geolocation button {
+    width: 100%;
 }
 
 

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14752,8 +14752,21 @@ var _marker_location_listener = require('./marker_location_listener');
 
 var _marker_location_listener2 = _interopRequireDefault(_marker_location_listener);
 
+var _list_location_listener = require('./list_location_listener');
+
+var _list_location_listener2 = _interopRequireDefault(_list_location_listener);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+// Import local files
+//
+// Local files can be imported directly using relative
+// paths "./socket" or full ones "web/static/js/socket".
+
+// import socket from "./socket"
+var MAP_ELEMENT_ID = 'map';
+
+// Here starts our application
 // Brunch automatically concatenates all files in your
 // watched paths. Those paths can be configured at
 // config.paths.watched in "brunch-config.js".
@@ -14767,17 +14780,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
-var MAP_ELEMENT_ID = 'map';
-
-// Here starts our application
-
-
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
 var map = _map_builder2.default.build(MAP_ELEMENT_ID);
 _example_markers2.default.renderInto(map);
 
@@ -14785,8 +14787,13 @@ _example_markers2.default.renderInto(map);
 var btnGeolocate = document.getElementById('geolocate');
 var geolocation = new _geolocation_handler2.default();
 geolocation.configure(btnGeolocate);
+
+// Add location listeners
 geolocation.addListener(new _console_location_listener2.default());
 geolocation.addListener(new _marker_location_listener2.default(map));
+var ulLocations = document.getElementById('locations');
+var listListener = new _list_location_listener2.default(ulLocations);
+geolocation.addListener(listListener);
 });
 
 require.register("web/static/js/console_location_listener.js", function(exports, require, module) {
@@ -14906,6 +14913,36 @@ GeolocationHandler.prototype.addListener = function (listener) {
 };
 
 exports.default = GeolocationHandler;
+});
+
+require.register("web/static/js/list_location_listener.js", function(exports, require, module) {
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+var ul = void 0,
+    locationId = 0;
+
+function ListLocationListener(ulElement) {
+    ul = ulElement;
+}
+
+// Location listeners must implement `newLocation` method
+ListLocationListener.prototype.newLocation = function (_ref) {
+    var latitude = _ref.latitude,
+        longitude = _ref.longitude;
+
+    locationId++;
+
+    var li = document.createElement('li');
+    var text = document.createTextNode('(#' + locationId + ') Lat: ' + latitude + ', Long: ' + longitude);
+    li.appendChild(text);
+
+    ul.insertBefore(li, ul.firstChild);
+};
+
+exports.default = ListLocationListener;
 });
 
 require.register("web/static/js/map_builder.js", function(exports, require, module) {
@@ -15047,8 +15084,8 @@ channel.join().receive("ok", function (resp) {
 exports.default = socket;
 });
 
-;require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
-require.alias("leaflet/dist/leaflet-src.js", "leaflet");
+;require.alias("leaflet/dist/leaflet-src.js", "leaflet");
+require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
 require.alias("phoenix/priv/static/phoenix.js", "phoenix");require.register("___globals___", function(exports, require, module) {
   
 });})();require('___globals___');

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14748,17 +14748,12 @@ var _console_location_listener = require('./console_location_listener');
 
 var _console_location_listener2 = _interopRequireDefault(_console_location_listener);
 
+var _marker_location_listener = require('./marker_location_listener');
+
+var _marker_location_listener2 = _interopRequireDefault(_marker_location_listener);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
-var MAP_ELEMENT_ID = 'map';
-
-// Here starts our application
 // Brunch automatically concatenates all files in your
 // watched paths. Those paths can be configured at
 // config.paths.watched in "brunch-config.js".
@@ -14772,6 +14767,17 @@ var MAP_ELEMENT_ID = 'map';
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
+var MAP_ELEMENT_ID = 'map';
+
+// Here starts our application
+
+
+// Import local files
+//
+// Local files can be imported directly using relative
+// paths "./socket" or full ones "web/static/js/socket".
+
+// import socket from "./socket"
 var map = _map_builder2.default.build(MAP_ELEMENT_ID);
 _example_markers2.default.renderInto(map);
 
@@ -14780,6 +14786,7 @@ var btnGeolocate = document.getElementById('geolocate');
 var geolocation = new _geolocation_handler2.default();
 geolocation.configure(btnGeolocate);
 geolocation.addListener(new _console_location_listener2.default());
+geolocation.addListener(new _marker_location_listener2.default(map));
 });
 
 require.register("web/static/js/console_location_listener.js", function(exports, require, module) {
@@ -14845,9 +14852,14 @@ var locationWatchId = void 0;
 var watching = false;
 var listeners = [];
 
-function onCurrentLocationChanged() {
+function onCurrentLocationChanged(location) {
+    var locationCoords = {
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude
+    };
+
     listeners.forEach(function (listener) {
-        return listener.newLocation();
+        return listener.newLocation(locationCoords);
     });
 }
 
@@ -14937,14 +14949,29 @@ require.register("web/static/js/marker_location_listener.js", function(exports, 
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-function ConsoleLocationListener() {}
+
+var _leaflet = require('leaflet');
+
+var _leaflet2 = _interopRequireDefault(_leaflet);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function MarkerLocationListener(map) {
+    this.map = map;
+}
 
 // Location listeners must implement `newLocation` method
-ConsoleLocationListener.prototype.newLocation = function () {
-    console.log('new location listened');
+MarkerLocationListener.prototype.newLocation = function (_ref) {
+    var latitude = _ref.latitude,
+        longitude = _ref.longitude;
+
+    console.log('new marker will be drawn');
+
+    // adds the location to the map
+    _leaflet2.default.marker([latitude, longitude]).addTo(this.map);
 };
 
-exports.default = ConsoleLocationListener;
+exports.default = MarkerLocationListener;
 });
 
 require.register("web/static/js/socket.js", function(exports, require, module) {

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14744,8 +14744,21 @@ var _geolocation_handler = require('./geolocation_handler');
 
 var _geolocation_handler2 = _interopRequireDefault(_geolocation_handler);
 
+var _console_location_listener = require('./console_location_listener');
+
+var _console_location_listener2 = _interopRequireDefault(_console_location_listener);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+// Import local files
+//
+// Local files can be imported directly using relative
+// paths "./socket" or full ones "web/static/js/socket".
+
+// import socket from "./socket"
+var MAP_ELEMENT_ID = 'map';
+
+// Here starts our application
 // Brunch automatically concatenates all files in your
 // watched paths. Those paths can be configured at
 // config.paths.watched in "brunch-config.js".
@@ -14759,17 +14772,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
-var MAP_ELEMENT_ID = 'map';
-
-// Here starts our application
-
-
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
 var map = _map_builder2.default.build(MAP_ELEMENT_ID);
 _example_markers2.default.renderInto(map);
 
@@ -14777,6 +14779,23 @@ _example_markers2.default.renderInto(map);
 var btnGeolocate = document.getElementById('geolocate');
 var geolocation = new _geolocation_handler2.default();
 geolocation.configure(btnGeolocate);
+geolocation.addListener(new _console_location_listener2.default());
+});
+
+require.register("web/static/js/console_location_listener.js", function(exports, require, module) {
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+// Location listeners must implement `newLocation` method
+function ConsoleLocationListener() {}
+
+ConsoleLocationListener.prototype.newLocation = function () {
+    console.log('new location listened');
+};
+
+exports.default = ConsoleLocationListener;
 });
 
 require.register("web/static/js/example_markers.js", function(exports, require, module) {
@@ -14910,6 +14929,22 @@ function build(elementId) {
 var MapBuilder = { build: build };
 
 exports.default = MapBuilder;
+});
+
+require.register("web/static/js/marker_location_listener.js", function(exports, require, module) {
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+function ConsoleLocationListener() {}
+
+// Location listeners must implement `newLocation` method
+ConsoleLocationListener.prototype.newLocation = function () {
+    console.log('new location listened');
+};
+
+exports.default = ConsoleLocationListener;
 });
 
 require.register("web/static/js/socket.js", function(exports, require, module) {

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14740,17 +14740,12 @@ var _example_markers = require('./example_markers');
 
 var _example_markers2 = _interopRequireDefault(_example_markers);
 
+var _geolocation_handler = require('./geolocation_handler');
+
+var _geolocation_handler2 = _interopRequireDefault(_geolocation_handler);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
-var MAP_ELEMENT_ID = 'map';
-
-// Here starts our application
 // Brunch automatically concatenates all files in your
 // watched paths. Those paths can be configured at
 // config.paths.watched in "brunch-config.js".
@@ -14764,8 +14759,24 @@ var MAP_ELEMENT_ID = 'map';
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
+var MAP_ELEMENT_ID = 'map';
+
+// Here starts our application
+
+
+// Import local files
+//
+// Local files can be imported directly using relative
+// paths "./socket" or full ones "web/static/js/socket".
+
+// import socket from "./socket"
 var map = _map_builder2.default.build(MAP_ELEMENT_ID);
 _example_markers2.default.renderInto(map);
+
+// Start geolocation
+var btnGeolocate = document.getElementById('geolocate');
+var geolocation = new _geolocation_handler2.default();
+geolocation.configure(btnGeolocate);
 });
 
 require.register("web/static/js/example_markers.js", function(exports, require, module) {
@@ -14799,6 +14810,71 @@ function renderInto(map) {
 var ExampleMarkers = { renderInto: renderInto };
 
 exports.default = ExampleMarkers;
+});
+
+require.register("web/static/js/geolocation_handler.js", function(exports, require, module) {
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+var STOP_WATCHING_TEXT = 'Stop';
+var START_WATCHING_TEXT = 'Start';
+
+var btnGeolocate = void 0;
+var locationWatchId = void 0;
+var watching = false;
+var listeners = [];
+
+function onCurrentLocationChanged() {
+    listeners.forEach(function (listener) {
+        return listener.newLocation();
+    });
+}
+
+function stopWatching() {
+    watching = false;
+    btnGeolocate.innerText = START_WATCHING_TEXT;
+    navigator.geolocation.clearWatch(locationWatchId);
+}
+
+function startWatching() {
+    watching = true;
+    btnGeolocate.innerText = STOP_WATCHING_TEXT;
+    locationWatchId = navigator.geolocation.watchPosition(onCurrentLocationChanged);
+}
+
+function onButtonGeolocateClick(event) {
+    event.preventDefault();
+
+    if (!navigator || !navigator.geolocation) {
+        alert('No se puede usar geolocalización en este navegador');
+        return;
+    }
+
+    if (watching) {
+        stopWatching();
+        return;
+    }
+
+    startWatching();
+}
+
+// constructor
+// This is the exported function/class
+function GeolocationHandler() {}
+
+GeolocationHandler.prototype.configure = function (element) {
+    btnGeolocate = element;
+    btnGeolocate.innerText = START_WATCHING_TEXT;
+    btnGeolocate.addEventListener('click', onButtonGeolocateClick);
+};
+
+GeolocationHandler.prototype.addListener = function (listener) {
+    listeners.push(listener);
+};
+
+exports.default = GeolocationHandler;
 });
 
 require.register("web/static/js/map_builder.js", function(exports, require, module) {
@@ -14909,9 +14985,9 @@ channel.join().receive("ok", function (resp) {
 exports.default = socket;
 });
 
-;require.alias("phoenix/priv/static/phoenix.js", "phoenix");
-require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
-require.alias("leaflet/dist/leaflet-src.js", "leaflet");require.register("___globals___", function(exports, require, module) {
+;require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
+require.alias("leaflet/dist/leaflet-src.js", "leaflet");
+require.alias("phoenix/priv/static/phoenix.js", "phoenix");require.register("___globals___", function(exports, require, module) {
   
 });})();require('___globals___');
 

--- a/apps/web/web/static/css/app.css
+++ b/apps/web/web/static/css/app.css
@@ -1,11 +1,25 @@
-
 body {
-  background-color: #b5d0d0;
-  margin: 0;
-  padding: 0;
+    background-color: #b5d0d0;
+    margin: 0;
+    padding: 0;
 }
 
 #map {
-  height: 100vh;
+    height: 100vh;
+}
+
+.left-panel {
+    width: 200px;
+    height: 100vh;
+    float: left;
+    border-right: solid 2px #b29ac3;
+}
+
+.geolocation {
+    margin-top: 1em;
+}
+
+.geolocation button {
+    width: 100%;
 }
 

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -23,6 +23,7 @@ import MapBuilder from './map_builder';
 import ExampleMarkers from './example_markers';
 import GeolocationHandler from './geolocation_handler';
 import ConsoleLocationListener from './console_location_listener';
+import MarkerLocationListener from './marker_location_listener';
 
 const MAP_ELEMENT_ID = 'map';
 
@@ -35,4 +36,5 @@ const btnGeolocate = document.getElementById('geolocate');
 const geolocation = new GeolocationHandler();
 geolocation.configure(btnGeolocate);
 geolocation.addListener(new ConsoleLocationListener());
+geolocation.addListener(new MarkerLocationListener(map));
 

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -21,10 +21,16 @@ import "phoenix_html"
 // import socket from "./socket"
 import MapBuilder from './map_builder';
 import ExampleMarkers from './example_markers';
+import GeolocationHandler from './geolocation_handler';
 
 const MAP_ELEMENT_ID = 'map';
 
 // Here starts our application
 const map = MapBuilder.build(MAP_ELEMENT_ID);
 ExampleMarkers.renderInto(map);
+
+// Start geolocation
+const btnGeolocate = document.getElementById('geolocate');
+const geolocation = new GeolocationHandler();
+geolocation.configure(btnGeolocate);
 

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -24,6 +24,7 @@ import ExampleMarkers from './example_markers';
 import GeolocationHandler from './geolocation_handler';
 import ConsoleLocationListener from './console_location_listener';
 import MarkerLocationListener from './marker_location_listener';
+import ListLocationListener from './list_location_listener';
 
 const MAP_ELEMENT_ID = 'map';
 
@@ -35,6 +36,11 @@ ExampleMarkers.renderInto(map);
 const btnGeolocate = document.getElementById('geolocate');
 const geolocation = new GeolocationHandler();
 geolocation.configure(btnGeolocate);
+
+// Add location listeners
 geolocation.addListener(new ConsoleLocationListener());
 geolocation.addListener(new MarkerLocationListener(map));
+const ulLocations = document.getElementById('locations');
+const listListener = new ListLocationListener(ulLocations);
+geolocation.addListener(listListener);
 

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -22,6 +22,7 @@ import "phoenix_html"
 import MapBuilder from './map_builder';
 import ExampleMarkers from './example_markers';
 import GeolocationHandler from './geolocation_handler';
+import ConsoleLocationListener from './console_location_listener';
 
 const MAP_ELEMENT_ID = 'map';
 
@@ -33,4 +34,5 @@ ExampleMarkers.renderInto(map);
 const btnGeolocate = document.getElementById('geolocate');
 const geolocation = new GeolocationHandler();
 geolocation.configure(btnGeolocate);
+geolocation.addListener(new ConsoleLocationListener());
 

--- a/apps/web/web/static/js/console_location_listener.js
+++ b/apps/web/web/static/js/console_location_listener.js
@@ -1,0 +1,9 @@
+// Location listeners must implement `newLocation` method
+function ConsoleLocationListener() {}
+
+ConsoleLocationListener.prototype.newLocation = function () {
+    console.log('new location listened');
+};
+
+export default ConsoleLocationListener;
+

--- a/apps/web/web/static/js/geolocation_handler.js
+++ b/apps/web/web/static/js/geolocation_handler.js
@@ -6,8 +6,13 @@ let locationWatchId;
 let watching = false;
 let listeners = [];
 
-function onCurrentLocationChanged() {
-    listeners.forEach(listener => listener.newLocation());
+function onCurrentLocationChanged(location) {
+    const locationCoords = {
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude
+    };
+
+    listeners.forEach(listener => listener.newLocation(locationCoords));
 }
 
 function stopWatching() {

--- a/apps/web/web/static/js/geolocation_handler.js
+++ b/apps/web/web/static/js/geolocation_handler.js
@@ -1,0 +1,56 @@
+const STOP_WATCHING_TEXT = 'Stop';
+const START_WATCHING_TEXT = 'Start';
+
+let btnGeolocate;
+let locationWatchId;
+let watching = false;
+let listeners = [];
+
+function onCurrentLocationChanged() {
+    listeners.forEach(listener => listener.newLocation());
+}
+
+function stopWatching() {
+    watching = false;
+    btnGeolocate.innerText = START_WATCHING_TEXT;
+    navigator.geolocation.clearWatch(locationWatchId);
+}
+
+function startWatching() {
+    watching = true;
+    btnGeolocate.innerText = STOP_WATCHING_TEXT;
+    locationWatchId = navigator.geolocation.watchPosition(onCurrentLocationChanged);
+}
+
+function onButtonGeolocateClick(event) {
+    event.preventDefault();
+
+    if (!navigator || !navigator.geolocation) {
+        alert('No se puede usar geolocalización en este navegador');
+        return;
+    }
+
+    if (watching) {
+        stopWatching();
+        return;
+    }
+
+    startWatching();
+}
+
+// constructor
+// This is the exported function/class
+function GeolocationHandler() { }
+
+GeolocationHandler.prototype.configure = function (element) {
+    btnGeolocate = element;
+    btnGeolocate.innerText = START_WATCHING_TEXT;
+    btnGeolocate.addEventListener('click', onButtonGeolocateClick);
+};
+
+GeolocationHandler.prototype.addListener = function (listener) {
+    listeners.push(listener);
+};
+
+export default GeolocationHandler;
+

--- a/apps/web/web/static/js/list_location_listener.js
+++ b/apps/web/web/static/js/list_location_listener.js
@@ -1,0 +1,20 @@
+let ul,
+    locationId = 0;
+
+function ListLocationListener(ulElement) {
+    ul = ulElement;
+}
+
+// Location listeners must implement `newLocation` method
+ListLocationListener.prototype.newLocation = function ({ latitude, longitude }) {
+    locationId++;
+
+    const li = document.createElement('li');
+    const text = document.createTextNode(`(#${locationId}) Lat: ${latitude}, Long: ${longitude}`);
+    li.appendChild(text);
+
+    ul.insertBefore(li, ul.firstChild);
+};
+
+export default ListLocationListener;
+

--- a/apps/web/web/static/js/marker_location_listener.js
+++ b/apps/web/web/static/js/marker_location_listener.js
@@ -1,0 +1,16 @@
+import L from 'leaflet';
+
+function MarkerLocationListener(map) {
+    this.map = map;
+}
+
+// Location listeners must implement `newLocation` method
+MarkerLocationListener.prototype.newLocation = function ({ latitude, longitude }) {
+    console.log('new marker will be drawn');
+
+    // adds the location to the map
+    L.marker([ latitude, longitude ]).addTo(this.map);
+};
+
+export default MarkerLocationListener;
+

--- a/apps/web/web/templates/map/index.html.eex
+++ b/apps/web/web/templates/map/index.html.eex
@@ -1,1 +1,10 @@
+<div class="left-panel">
+    <div class="geolocation">
+        <form>
+            <button id="geolocate">Geolocate yourself</button>
+        </form>
+        <ul id="locations"/>
+    </div>
+</div>
+
 <div id="map"></div>


### PR DESCRIPTION
Añade un botón en el margen izquierdo. El usuario habilita/inhabilita la geolocalización mediante ese botón.

El módulo JS que la gestiona (quien habla con el navegador para obtener la localización del usuario) permite que se le añadan *listeners*, de forma que puede notificar a otros módulos.

El PR también crea varios de estos módulos *listeners*. Por ejemplo, uno que dibuja un marcador en el mapa por cada localización y otro que escribe las localizaciones como texto debajo del botón.

---

Ahora ya podemos crear un módulo que escuche las localizaciones y que las envíe al servidor a través de un web socket :muscle: 