### PR TITLE
Añadir simulador al panel lateral

### DIFF
--- a/apps/web/priv/static/css/app.css
+++ b/apps/web/priv/static/css/app.css
@@ -722,12 +722,24 @@ body {
     border-right: solid 2px #b29ac3;
 }
 
+.simulator label {
+    width: 100%;
+    margin: 0 5%;
+}
+
+.simulator input,
+.simulator button {
+    width: 90%;
+    margin: 0 5%;
+}
+
 .geolocation {
     margin-top: 1em;
 }
 
 .geolocation button {
-    width: 100%;
+    width: 90%;
+    margin: 0 5%;
 }
 
 

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14756,17 +14756,12 @@ var _list_location_listener = require('./list_location_listener');
 
 var _list_location_listener2 = _interopRequireDefault(_list_location_listener);
 
+var _simulator_handler = require('./simulator_handler');
+
+var _simulator_handler2 = _interopRequireDefault(_simulator_handler);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
-var MAP_ELEMENT_ID = 'map';
-
-// Here starts our application
 // Brunch automatically concatenates all files in your
 // watched paths. Those paths can be configured at
 // config.paths.watched in "brunch-config.js".
@@ -14780,6 +14775,17 @@ var MAP_ELEMENT_ID = 'map';
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
+var MAP_ELEMENT_ID = 'map';
+
+// Here starts our application
+
+
+// Import local files
+//
+// Local files can be imported directly using relative
+// paths "./socket" or full ones "web/static/js/socket".
+
+// import socket from "./socket"
 var map = _map_builder2.default.build(MAP_ELEMENT_ID);
 _example_markers2.default.renderInto(map);
 
@@ -14794,6 +14800,18 @@ geolocation.addListener(new _marker_location_listener2.default(map));
 var ulLocations = document.getElementById('locations');
 var listListener = new _list_location_listener2.default(ulLocations);
 geolocation.addListener(listListener);
+
+// Create and configure simulator
+var latitudeInput = document.getElementById('latitude');
+var lontitudeInput = document.getElementById('longitude');
+var renderButton = document.getElementById('render');
+var simulator = new _simulator_handler2.default();
+simulator.configure(latitudeInput, lontitudeInput, renderButton);
+
+// add geolocaiton listeners to the simulator
+simulator.addListener(new _console_location_listener2.default());
+simulator.addListener(new _marker_location_listener2.default(map));
+simulator.addListener(listListener);
 });
 
 require.register("web/static/js/console_location_listener.js", function(exports, require, module) {
@@ -15011,6 +15029,67 @@ MarkerLocationListener.prototype.newLocation = function (_ref) {
 exports.default = MarkerLocationListener;
 });
 
+require.register("web/static/js/simulator_handler.js", function(exports, require, module) {
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var latitude = void 0;
+var longitude = void 0;
+var render = void 0;
+var listeners = [];
+
+function getFloat($input) {
+    var value = $input.value;
+    return parseFloat(value);
+}
+
+function onRenderButtonClick(event) {
+    event.preventDefault();
+
+    var latitudeValue = getFloat(latitude);
+    if (isNaN(latitudeValue)) {
+        alert('Latitude should be a number like "12.34"');
+        return;
+    }
+
+    var longitudeValue = getFloat(longitude);
+    if (isNaN(longitudeValue)) {
+        alert('Longitude should be a number like "12.34"');
+        return;
+    }
+
+    var locationCoords = {
+        latitude: latitudeValue,
+        longitude: longitudeValue
+    };
+
+    listeners.forEach(function (listener) {
+        return listener.newLocation(locationCoords);
+    });
+}
+
+// constructor
+// This is the exported function/class
+function SimulatorHandler() {}
+
+SimulatorHandler.prototype.configure = function (latitudeInput, lontitudeInput, renderButton) {
+    latitude = latitudeInput;
+    longitude = lontitudeInput;
+    render = renderButton;
+
+    render.addEventListener('click', onRenderButtonClick);
+};
+
+SimulatorHandler.prototype.addListener = function (listener) {
+    listeners.push(listener);
+};
+
+exports.default = SimulatorHandler;
+});
+
 require.register("web/static/js/socket.js", function(exports, require, module) {
 "use strict";
 
@@ -15084,9 +15163,9 @@ channel.join().receive("ok", function (resp) {
 exports.default = socket;
 });
 
-;require.alias("leaflet/dist/leaflet-src.js", "leaflet");
-require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
-require.alias("phoenix/priv/static/phoenix.js", "phoenix");require.register("___globals___", function(exports, require, module) {
+;require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
+require.alias("phoenix/priv/static/phoenix.js", "phoenix");
+require.alias("leaflet/dist/leaflet-src.js", "leaflet");require.register("___globals___", function(exports, require, module) {
   
 });})();require('___globals___');
 

--- a/apps/web/web/static/css/app.css
+++ b/apps/web/web/static/css/app.css
@@ -15,11 +15,23 @@ body {
     border-right: solid 2px #b29ac3;
 }
 
+.simulator label {
+    width: 100%;
+    margin: 0 5%;
+}
+
+.simulator input,
+.simulator button {
+    width: 90%;
+    margin: 0 5%;
+}
+
 .geolocation {
     margin-top: 1em;
 }
 
 .geolocation button {
-    width: 100%;
+    width: 90%;
+    margin: 0 5%;
 }
 

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -25,6 +25,7 @@ import GeolocationHandler from './geolocation_handler';
 import ConsoleLocationListener from './console_location_listener';
 import MarkerLocationListener from './marker_location_listener';
 import ListLocationListener from './list_location_listener';
+import SimulatorHandler from './simulator_handler';
 
 const MAP_ELEMENT_ID = 'map';
 
@@ -43,4 +44,16 @@ geolocation.addListener(new MarkerLocationListener(map));
 const ulLocations = document.getElementById('locations');
 const listListener = new ListLocationListener(ulLocations);
 geolocation.addListener(listListener);
+
+// Create and configure simulator
+const latitudeInput = document.getElementById('latitude');
+const lontitudeInput = document.getElementById('longitude');
+const renderButton = document.getElementById('render');
+const simulator = new SimulatorHandler();
+simulator.configure(latitudeInput, lontitudeInput, renderButton);
+
+// add geolocaiton listeners to the simulator
+simulator.addListener(new ConsoleLocationListener());
+simulator.addListener(new MarkerLocationListener(map));
+simulator.addListener(listListener);
 

--- a/apps/web/web/static/js/simulator_handler.js
+++ b/apps/web/web/static/js/simulator_handler.js
@@ -1,0 +1,52 @@
+
+let latitude;
+let longitude;
+let render;
+const listeners = [];
+
+function getFloat($input) {
+    const value = $input.value;
+    return parseFloat(value);
+}
+
+function onRenderButtonClick(event) {
+    event.preventDefault();
+
+    const latitudeValue = getFloat(latitude);
+    if (isNaN(latitudeValue)) {
+        alert('Latitude should be a number like "12.34"');
+        return;
+    }
+
+    const longitudeValue = getFloat(longitude);
+    if (isNaN(longitudeValue)) {
+        alert('Longitude should be a number like "12.34"');
+        return;
+    }
+
+    const locationCoords = {
+        latitude: latitudeValue,
+        longitude: longitudeValue
+    };
+
+    listeners.forEach(listener => listener.newLocation(locationCoords));
+}
+
+// constructor
+// This is the exported function/class
+function SimulatorHandler() { }
+
+SimulatorHandler.prototype.configure = function (latitudeInput, lontitudeInput, renderButton) {
+    latitude = latitudeInput;
+    longitude = lontitudeInput;
+    render = renderButton;
+
+    render.addEventListener('click', onRenderButtonClick);
+};
+
+SimulatorHandler.prototype.addListener = function (listener) {
+    listeners.push(listener);
+};
+
+export default SimulatorHandler;
+

--- a/apps/web/web/templates/map/index.html.eex
+++ b/apps/web/web/templates/map/index.html.eex
@@ -1,4 +1,15 @@
 <div class="left-panel">
+    <div class="simulator">
+        <form>
+            <label for="latitude">Latitude:</label>
+            <input type="text" id="latitude" name="latitude" placeholder="40.4169"/>
+
+            <label for="longitude">Longitude:</label>
+            <input type="text" id="longitude" name="longitude" placeholder="-3.7035"/>
+
+            <button id="render">Render</button>
+        </form>
+    </div>
     <div class="geolocation">
         <form>
             <button id="geolocate">Geolocate yourself</button>


### PR DESCRIPTION
Para igualar la aplicación de verdad con la prueba de concepto inicial, este PR añade un par de campos en el panel lateral donde el usuario puede introducir las coordenadas de su posición de forma manual.

Lo chulo es que el *simulador* admite *location listeners*. Añadiéndole los mismos listeners que al componente de geolocalización, todos los datos se muestran en el mapa y se listan en el panel lateral.