### PR TITLE
Envia posiciones al servidor y el servidor las responde

### DIFF
--- a/apps/web/lib/web/endpoint.ex
+++ b/apps/web/lib/web/endpoint.ex
@@ -2,6 +2,7 @@ defmodule Web.Endpoint do
   use Phoenix.Endpoint, otp_app: :web
 
   socket "/socket", Web.UserSocket
+  socket "/locations_socket", Web.LocationsSocket
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14728,53 +14728,48 @@ window.addEventListener('click', function (event) {
   })();
 });
 require.register("web/static/js/app.js", function(exports, require, module) {
-'use strict';
+"use strict";
 
-require('phoenix_html');
+require("phoenix_html");
 
-var _leaflet_map = require('./leaflet/leaflet_map');
+var _socket = require("./socket");
+
+var _socket2 = _interopRequireDefault(_socket);
+
+var _leaflet_map = require("./leaflet/leaflet_map");
 
 var _leaflet_map2 = _interopRequireDefault(_leaflet_map);
 
-var _example_markers = require('./leaflet/example_markers');
+var _example_markers = require("./leaflet/example_markers");
 
 var _example_markers2 = _interopRequireDefault(_example_markers);
 
-var _browser_geolocation = require('./geolocation/browser_geolocation');
+var _browser_geolocation = require("./geolocation/browser_geolocation");
 
 var _browser_geolocation2 = _interopRequireDefault(_browser_geolocation);
 
-var _geolocation_handler = require('./geolocation/geolocation_handler');
+var _geolocation_handler = require("./geolocation/geolocation_handler");
 
 var _geolocation_handler2 = _interopRequireDefault(_geolocation_handler);
 
-var _console_location_listener = require('./geolocation/listeners/console_location_listener');
+var _console_location_listener = require("./geolocation/listeners/console_location_listener");
 
 var _console_location_listener2 = _interopRequireDefault(_console_location_listener);
 
-var _marker_location_listener = require('./geolocation/listeners/marker_location_listener');
+var _marker_location_listener = require("./geolocation/listeners/marker_location_listener");
 
 var _marker_location_listener2 = _interopRequireDefault(_marker_location_listener);
 
-var _list_location_listener = require('./geolocation/listeners/list_location_listener');
+var _list_location_listener = require("./geolocation/listeners/list_location_listener");
 
 var _list_location_listener2 = _interopRequireDefault(_list_location_listener);
 
-var _simulator_handler = require('./geolocation/simulator_handler');
+var _simulator_handler = require("./geolocation/simulator_handler");
 
 var _simulator_handler2 = _interopRequireDefault(_simulator_handler);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
-var MAP_ELEMENT_ID = 'map';
-
-// Here starts our application
 // Brunch automatically concatenates all files in your
 // watched paths. Those paths can be configured at
 // config.paths.watched in "brunch-config.js".
@@ -14788,6 +14783,16 @@ var MAP_ELEMENT_ID = 'map';
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
+var MAP_ELEMENT_ID = 'map';
+
+// Here starts our application
+
+
+// Import local files
+//
+// Local files can be imported directly using relative
+// paths "./socket" or full ones "web/static/js/socket".
+
 var map = new _leaflet_map2.default(MAP_ELEMENT_ID);
 _example_markers2.default.renderInto(map);
 
@@ -15131,7 +15136,7 @@ Object.defineProperty(exports, "__esModule", {
 
 var _phoenix = require("phoenix");
 
-var socket = new _phoenix.Socket("/socket", { params: { token: window.userToken } });
+var socket = new _phoenix.Socket("/locations_socket", { params: { token: window.userToken } });
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -15185,19 +15190,30 @@ var socket = new _phoenix.Socket("/socket", { params: { token: window.userToken 
 socket.connect();
 
 // Now that you are connected, you can join channels with a topic:
-var channel = socket.channel("topic:subtopic", {});
+var channel = socket.channel("location:all", {});
 channel.join().receive("ok", function (resp) {
   console.log("Joined successfully", resp);
 }).receive("error", function (resp) {
   console.log("Unable to join", resp);
 });
 
+// send a msg after 3sg
+setTimeout(function () {
+  channel.push('new_msg', { body: 'Body of the message' });
+  console.log('msg sent');
+}, 3000);
+
+// show received msgs in the console
+channel.on('new_msg', function (payload) {
+  console.log('He recibido un cuerpo de msg:', payload.body);
+});
+
 exports.default = socket;
 });
 
-;require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
-require.alias("phoenix/priv/static/phoenix.js", "phoenix");
-require.alias("leaflet/dist/leaflet-src.js", "leaflet");require.register("___globals___", function(exports, require, module) {
+require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
+require.alias("leaflet/dist/leaflet-src.js", "leaflet");
+require.alias("phoenix/priv/static/phoenix.js", "phoenix");require.register("___globals___", function(exports, require, module) {
   
 });})();require('___globals___');
 

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14822,87 +14822,60 @@ simulator.addListener(listListener);
 });
 
 require.register("web/static/js/communication/channel.js", function(exports, require, module) {
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _phoenix = require("phoenix");
+var _phoenix = require('phoenix');
 
-var socket = new _phoenix.Socket("/locations_socket", { params: { token: window.userToken } });
+function notify(payload, listeners) {
+  listeners.forEach(function (listener) {
+    return listener.onMessageReceived(payload.body);
+  });
+}
 
-// When you connect, you'll often need to authenticate the client.
-// For example, imagine you have an authentication plug, `MyAuth`,
-// which authenticates the session and assigns a `:current_user`.
-// If the current user exists you can assign the user's token in
-// the connection for use in the layout.
-//
-// In your "web/router.ex":
-//
-//     pipeline :browser do
-//       ...
-//       plug MyAuth
-//       plug :put_user_token
-//     end
-//
-//     defp put_user_token(conn, _) do
-//       if current_user = conn.assigns[:current_user] do
-//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
-//         assign(conn, :user_token, token)
-//       else
-//         conn
-//       end
-//     end
-//
-// Now you need to pass this token to JavaScript. You can do so
-// inside a script tag in "web/templates/layout/app.html.eex":
-//
-//     <script>window.userToken = "<%= assigns[:user_token] %>";</script>
-//
-// You will need to verify the user token in the "connect/2" function
-// in "web/channels/user_socket.ex":
-//
-//     def connect(%{"token" => token}, socket) do
-//       # max_age: 1209600 is equivalent to two weeks in seconds
-//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1209600) do
-//         {:ok, user_id} ->
-//           {:ok, assign(socket, :user, user_id)}
-//         {:error, reason} ->
-//           :error
-//       end
-//     end
-//
-// Finally, pass the token on connect as below. Or remove it
-// from connect if you don't care about authentication.
+function Channel() {
+  this.connected = false;
+  this.channel = null;
+  this.listeners = [];
+}
 
-// NOTE: The contents of this file will only be executed if
-// you uncomment its entry in "web/static/js/app.js".
+Channel.prototype.init = function () {
+  var _this = this;
 
-// To use Phoenix channels, the first step is to import Socket
-// and connect at the socket path in "lib/my_app/endpoint.ex":
-socket.connect();
+  var socket = new _phoenix.Socket('/locations_socket', { params: { token: window.userToken } });
+  socket.connect();
 
-// Now that you are connected, you can join channels with a topic:
-var channel = socket.channel("location:all", {});
-channel.join().receive("ok", function (resp) {
-  console.log("Joined successfully", resp);
-}).receive("error", function (resp) {
-  console.log("Unable to join", resp);
-});
+  this.channel = socket.channel('location:all', {});
+  this.channel.join().receive('ok', function (resp) {
+    _this.connected = true;
+    console.log('Joined successfully', resp);
+  }).receive('error', function (resp) {
+    _this.connected = false;
+    console.log('Unable to join', resp);
+  });
 
-// send a msg after 3sg
-setTimeout(function () {
-  channel.push('new_msg', { body: 'Body of the message' });
-  console.log('msg sent');
-}, 3000);
+  this.channel.on('location_message', function (payload) {
+    notify(payload, _this.listeners);
+  });
+};
 
-// show received msgs in the console
-channel.on('new_msg', function (payload) {
-  console.log('He recibido un cuerpo de msg:', payload.body);
-});
+Channel.prototype.send = function (body) {
+  if (!this.connected) {
+    throw new Error('Must be connected to send messages');
+  }
 
-exports.default = socket;
+  var message = { body: body };
+  this.channel.push('location_message', message);
+};
+
+Channel.prototype.addListener = function (listener) {
+  this.listeners.add(listener);
+};
+
+exports.default = Channel;
 });
 
 require.register("web/static/js/geolocation/browser_geolocation.js", function(exports, require, module) {

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14821,6 +14821,90 @@ simulator.addListener(new _marker_location_listener2.default(map));
 simulator.addListener(listListener);
 });
 
+require.register("web/static/js/communication/channel.js", function(exports, require, module) {
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _phoenix = require("phoenix");
+
+var socket = new _phoenix.Socket("/locations_socket", { params: { token: window.userToken } });
+
+// When you connect, you'll often need to authenticate the client.
+// For example, imagine you have an authentication plug, `MyAuth`,
+// which authenticates the session and assigns a `:current_user`.
+// If the current user exists you can assign the user's token in
+// the connection for use in the layout.
+//
+// In your "web/router.ex":
+//
+//     pipeline :browser do
+//       ...
+//       plug MyAuth
+//       plug :put_user_token
+//     end
+//
+//     defp put_user_token(conn, _) do
+//       if current_user = conn.assigns[:current_user] do
+//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
+//         assign(conn, :user_token, token)
+//       else
+//         conn
+//       end
+//     end
+//
+// Now you need to pass this token to JavaScript. You can do so
+// inside a script tag in "web/templates/layout/app.html.eex":
+//
+//     <script>window.userToken = "<%= assigns[:user_token] %>";</script>
+//
+// You will need to verify the user token in the "connect/2" function
+// in "web/channels/user_socket.ex":
+//
+//     def connect(%{"token" => token}, socket) do
+//       # max_age: 1209600 is equivalent to two weeks in seconds
+//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1209600) do
+//         {:ok, user_id} ->
+//           {:ok, assign(socket, :user, user_id)}
+//         {:error, reason} ->
+//           :error
+//       end
+//     end
+//
+// Finally, pass the token on connect as below. Or remove it
+// from connect if you don't care about authentication.
+
+// NOTE: The contents of this file will only be executed if
+// you uncomment its entry in "web/static/js/app.js".
+
+// To use Phoenix channels, the first step is to import Socket
+// and connect at the socket path in "lib/my_app/endpoint.ex":
+socket.connect();
+
+// Now that you are connected, you can join channels with a topic:
+var channel = socket.channel("location:all", {});
+channel.join().receive("ok", function (resp) {
+  console.log("Joined successfully", resp);
+}).receive("error", function (resp) {
+  console.log("Unable to join", resp);
+});
+
+// send a msg after 3sg
+setTimeout(function () {
+  channel.push('new_msg', { body: 'Body of the message' });
+  console.log('msg sent');
+}, 3000);
+
+// show received msgs in the console
+channel.on('new_msg', function (payload) {
+  console.log('He recibido un cuerpo de msg:', payload.body);
+});
+
+exports.default = socket;
+});
+
 require.register("web/static/js/geolocation/browser_geolocation.js", function(exports, require, module) {
 "use strict";
 
@@ -15211,9 +15295,9 @@ channel.on('new_msg', function (payload) {
 exports.default = socket;
 });
 
+require.alias("phoenix/priv/static/phoenix.js", "phoenix");
 require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
-require.alias("leaflet/dist/leaflet-src.js", "leaflet");
-require.alias("phoenix/priv/static/phoenix.js", "phoenix");require.register("___globals___", function(exports, require, module) {
+require.alias("leaflet/dist/leaflet-src.js", "leaflet");require.register("___globals___", function(exports, require, module) {
   
 });})();require('___globals___');
 

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -14794,15 +14794,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var MAP_ELEMENT_ID = 'map';
 
 // Here starts our application
-
-
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
-
 var map = new _leaflet_map2.default(MAP_ELEMENT_ID);
 _example_markers2.default.renderInto(map);
 
@@ -14813,7 +14804,7 @@ geolocation.configure(btnGeolocate);
 
 // Add location listeners
 geolocation.addListener(new _console_location_listener2.default());
-// geolocation.addListener(new MarkerLocationListener(map));
+// geolocation.addListener(new MarkerLocationListener(map)); // this is added later, to draw locations sent by the server
 var ulLocations = document.getElementById('locations');
 var listListener = new _list_location_listener2.default(ulLocations);
 geolocation.addListener(listListener);
@@ -14827,7 +14818,7 @@ simulator.configure(latitudeInput, lontitudeInput, renderButton);
 
 // add geolocation listeners to the simulator
 simulator.addListener(new _console_location_listener2.default());
-simulator.addListener(new _marker_location_listener2.default(map));
+// simulator.addListener(new MarkerLocationListener(map));  // this is added later, to draw locations sent by the server
 simulator.addListener(listListener);
 
 // create and initialize channel with server
@@ -14837,9 +14828,11 @@ channel.init();
 // add listeners related to the channel
 var sendToServerLocationListener = new _send_to_server_location_listener2.default(channel);
 geolocation.addListener(sendToServerLocationListener);
+simulator.addListener(sendToServerLocationListener);
 
-var messageToLocation = new _message_to_location_broker2.default(new _marker_location_listener2.default(map));
-channel.addListener(messageToLocation);
+// message broker
+var broker = new _message_to_location_broker2.default(new _marker_location_listener2.default(map));
+channel.addListener(broker);
 });
 
 require.register("web/static/js/communication/channel.js", function(exports, require, module) {

--- a/apps/web/priv/static/js/app.js
+++ b/apps/web/priv/static/js/app.js
@@ -15331,9 +15331,9 @@ channel.on('new_msg', function (payload) {
 exports.default = socket;
 });
 
-require.alias("phoenix/priv/static/phoenix.js", "phoenix");
+require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
 require.alias("leaflet/dist/leaflet-src.js", "leaflet");
-require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");require.register("___globals___", function(exports, require, module) {
+require.alias("phoenix/priv/static/phoenix.js", "phoenix");require.register("___globals___", function(exports, require, module) {
   
 });})();require('___globals___');
 

--- a/apps/web/web/channels/location_channel.ex
+++ b/apps/web/web/channels/location_channel.ex
@@ -7,4 +7,14 @@ defmodule Web.LocationChannel do
   def join("location:" <> _private_room_id, _params, _socket) do
     {:error, %{reason: "unauthorized"}}
   end
+
+  def handle_in("new_msg", %{"body" => body}, socket) do
+    broadcast! socket, "new_msg", %{body: body}
+    {:noreply, socket}
+  end
+
+  def handle_out("new_msg", payload, socket) do
+    push socket, "new_msg", payload
+    {:noreply, socket}
+  end
 end

--- a/apps/web/web/channels/location_channel.ex
+++ b/apps/web/web/channels/location_channel.ex
@@ -8,13 +8,13 @@ defmodule Web.LocationChannel do
     {:error, %{reason: "unauthorized"}}
   end
 
-  def handle_in("new_msg", %{"body" => body}, socket) do
-    broadcast! socket, "new_msg", %{body: body}
+  def handle_in("location_message", %{"body" => body}, socket) do
+    broadcast! socket, "location_message", %{body: body}
     {:noreply, socket}
   end
 
-  def handle_out("new_msg", payload, socket) do
-    push socket, "new_msg", payload
+  def handle_out("location_message", payload, socket) do
+    push socket, "location_message", payload
     {:noreply, socket}
   end
 end

--- a/apps/web/web/channels/location_channel.ex
+++ b/apps/web/web/channels/location_channel.ex
@@ -1,0 +1,10 @@
+defmodule Web.LocationChannel do
+  use Phoenix.Channel
+
+  def join("location:all", _message, socket) do
+    {:ok, socket}
+  end
+  def join("location:" <> _private_room_id, _params, _socket) do
+    {:error, %{reason: "unauthorized"}}
+  end
+end

--- a/apps/web/web/channels/locations_socket.ex
+++ b/apps/web/web/channels/locations_socket.ex
@@ -1,0 +1,37 @@
+defmodule Web.LocationsSocket do
+  use Phoenix.Socket
+
+  ## Channels
+  channel "location:*", Web.LocationChannel
+
+  ## Transports
+  transport :websocket, Phoenix.Transports.WebSocket
+  # transport :longpoll, Phoenix.Transports.LongPoll
+
+  # Socket params are passed from the client and can
+  # be used to verify and authenticate a user. After
+  # verification, you can put default assigns into
+  # the socket that will be set for all channels, ie
+  #
+  #     {:ok, assign(socket, :user_id, verified_user_id)}
+  #
+  # To deny connection, return `:error`.
+  #
+  # See `Phoenix.Token` documentation for examples in
+  # performing token verification on connect.
+  def connect(_params, socket) do
+    {:ok, socket}
+  end
+
+  # Socket id's are topics that allow you to identify all sockets for a given user:
+  #
+  #     def id(socket), do: "users_socket:#{socket.assigns.user_id}"
+  #
+  # Would allow you to broadcast a "disconnect" event and terminate
+  # all active sockets and channels for a given user:
+  #
+  #     Web.Endpoint.broadcast("users_socket:#{user.id}", "disconnect", %{})
+  #
+  # Returning `nil` makes this socket anonymous.
+  def id(_socket), do: nil
+end

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -18,7 +18,7 @@ import "phoenix_html"
 // Local files can be imported directly using relative
 // paths "./socket" or full ones "web/static/js/socket".
 
-import socket from "./socket"
+// import socket from "./socket"
 
 import LeafletMap from './leaflet/leaflet_map';
 import ExampleMarkers from './leaflet/example_markers';
@@ -27,7 +27,10 @@ import GeolocationHandler from './geolocation/geolocation_handler';
 import ConsoleLocationListener from './geolocation/listeners/console_location_listener';
 import MarkerLocationListener from './geolocation/listeners/marker_location_listener';
 import ListLocationListener from './geolocation/listeners/list_location_listener';
+import SendToServerLocationListener from './geolocation/listeners/send_to_server_location_listener';
 import SimulatorHandler from './geolocation/simulator_handler';
+import Channel from './communication/channel';
+import MessageToLocationBroker from './communication/listeners/message_to_location_broker';
 
 const MAP_ELEMENT_ID = 'map';
 
@@ -42,7 +45,7 @@ geolocation.configure(btnGeolocate);
 
 // Add location listeners
 geolocation.addListener(new ConsoleLocationListener());
-geolocation.addListener(new MarkerLocationListener(map));
+// geolocation.addListener(new MarkerLocationListener(map));
 const ulLocations = document.getElementById('locations');
 const listListener = new ListLocationListener(ulLocations);
 geolocation.addListener(listListener);
@@ -54,8 +57,19 @@ const renderButton = document.getElementById('render');
 const simulator = new SimulatorHandler();
 simulator.configure(latitudeInput, lontitudeInput, renderButton);
 
-// add geolocaiton listeners to the simulator
+// add geolocation listeners to the simulator
 simulator.addListener(new ConsoleLocationListener());
 simulator.addListener(new MarkerLocationListener(map));
 simulator.addListener(listListener);
+
+// create and initialize channel with server
+const channel = new Channel();
+channel.init();
+
+// add listeners related to the channel
+const sendToServerLocationListener = new SendToServerLocationListener(channel);
+geolocation.addListener(sendToServerLocationListener);
+
+const messageToLocation = new MessageToLocationBroker(new MarkerLocationListener(map));
+channel.addListener(messageToLocation);
 

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -18,7 +18,8 @@ import "phoenix_html"
 // Local files can be imported directly using relative
 // paths "./socket" or full ones "web/static/js/socket".
 
-// import socket from "./socket"
+import socket from "./socket"
+
 import LeafletMap from './leaflet/leaflet_map';
 import ExampleMarkers from './leaflet/example_markers';
 import BrowserGeolocation from './geolocation/browser_geolocation';

--- a/apps/web/web/static/js/app.js
+++ b/apps/web/web/static/js/app.js
@@ -13,13 +13,6 @@
 // to also remove its path from "config.paths.watched".
 import "phoenix_html"
 
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
-// import socket from "./socket"
-
 import LeafletMap from './leaflet/leaflet_map';
 import ExampleMarkers from './leaflet/example_markers';
 import BrowserGeolocation from './geolocation/browser_geolocation';
@@ -45,7 +38,7 @@ geolocation.configure(btnGeolocate);
 
 // Add location listeners
 geolocation.addListener(new ConsoleLocationListener());
-// geolocation.addListener(new MarkerLocationListener(map));
+// geolocation.addListener(new MarkerLocationListener(map)); // this is added later, to draw locations sent by the server
 const ulLocations = document.getElementById('locations');
 const listListener = new ListLocationListener(ulLocations);
 geolocation.addListener(listListener);
@@ -59,7 +52,7 @@ simulator.configure(latitudeInput, lontitudeInput, renderButton);
 
 // add geolocation listeners to the simulator
 simulator.addListener(new ConsoleLocationListener());
-simulator.addListener(new MarkerLocationListener(map));
+// simulator.addListener(new MarkerLocationListener(map));  // this is added later, to draw locations sent by the server
 simulator.addListener(listListener);
 
 // create and initialize channel with server
@@ -69,7 +62,9 @@ channel.init();
 // add listeners related to the channel
 const sendToServerLocationListener = new SendToServerLocationListener(channel);
 geolocation.addListener(sendToServerLocationListener);
+simulator.addListener(sendToServerLocationListener);
 
-const messageToLocation = new MessageToLocationBroker(new MarkerLocationListener(map));
-channel.addListener(messageToLocation);
+// message broker
+const broker = new MessageToLocationBroker(new MarkerLocationListener(map));
+channel.addListener(broker);
 

--- a/apps/web/web/static/js/communication/channel.js
+++ b/apps/web/web/static/js/communication/channel.js
@@ -26,6 +26,7 @@ Channel.prototype.init = function () {
     });
 
   this.channel.on('location_message', payload => {
+    console.log('location_message messge received. payload:', payload);
     notify(payload, this.listeners);
   });
 }
@@ -40,7 +41,7 @@ Channel.prototype.send = function (body) {
 };
 
 Channel.prototype.addListener = function (listener) {
-  this.listeners.add(listener);
+  this.listeners.push(listener);
 };
 
 export default Channel;

--- a/apps/web/web/static/js/communication/channel.js
+++ b/apps/web/web/static/js/communication/channel.js
@@ -1,0 +1,47 @@
+import { Socket } from "phoenix";
+
+function notify(payload, listeners) {
+  listeners.forEach(listener => listener.onMessageReceived(payload.body));
+}
+
+function Channel() {
+  this.connected = false;
+  this.channel = null;
+  this.listeners = [];
+}
+
+Channel.prototype.init = function () {
+  let socket = new Socket('/locations_socket', {params: {token: window.userToken}});
+  socket.connect();
+
+  this.channel = socket.channel('location:all', {});
+  this.channel.join()
+    .receive('ok', resp => {
+      this.connected = true;
+      console.log('Joined successfully', resp);
+    })
+    .receive('error', resp => {
+      this.connected = false;
+      console.log('Unable to join', resp);
+    });
+
+  this.channel.on('location_message', payload => {
+    notify(payload, this.listeners);
+  });
+}
+
+Channel.prototype.send = function (body) {
+  if (!this.connected) {
+    throw new Error('Must be connected to send messages');
+  }
+
+  const message = { body };
+  this.channel.push('location_message', message);  
+};
+
+Channel.prototype.addListener = function (listener) {
+  this.listeners.add(listener);
+};
+
+export default Channel;
+

--- a/apps/web/web/static/js/communication/listeners/message_to_location_broker.js
+++ b/apps/web/web/static/js/communication/listeners/message_to_location_broker.js
@@ -1,0 +1,14 @@
+
+// Gets a message from a channel with the server and sends it
+// to a location listener
+function MessageToLocationBroker (locationListener) {
+    this.locationListener = locationListener;
+}
+
+MessageToLocationBroker.prototype.onMessageReceived = function (body) {
+    console.log('body received in the broker', body);
+    this.locationListener.newLocation(body);
+};
+
+export default MessageToLocationBroker;
+

--- a/apps/web/web/static/js/geolocation/listeners/send_to_server_location_listener.js
+++ b/apps/web/web/static/js/geolocation/listeners/send_to_server_location_listener.js
@@ -1,0 +1,13 @@
+// Location listeners must implement `newLocation` method
+function SendToServerLocationListener(channel) {
+    this.channel = channel;
+}
+
+SendToServerLocationListener.prototype.newLocation = function (location) {
+    console.log('location will be sent to server:', location);
+
+    this.channel.send(location);
+};
+
+export default SendToServerLocationListener;
+

--- a/apps/web/web/static/js/socket.js
+++ b/apps/web/web/static/js/socket.js
@@ -3,9 +3,9 @@
 
 // To use Phoenix channels, the first step is to import Socket
 // and connect at the socket path in "lib/my_app/endpoint.ex":
-import {Socket} from "phoenix"
+import { Socket } from "phoenix";
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+let socket = new Socket("/locations_socket", {params: {token: window.userToken}});
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -51,12 +51,24 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 // Finally, pass the token on connect as below. Or remove it
 // from connect if you don't care about authentication.
 
-socket.connect()
+socket.connect();
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
+let channel = socket.channel("location:all", {});
 channel.join()
   .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) });
 
-export default socket
+// send a msg after 3sg
+setTimeout(() => {
+  channel.push('new_msg', { body: 'Body of the message' });
+  console.log('msg sent');
+  }, 3000);
+
+// show received msgs in the console
+channel.on('new_msg', payload => {
+  console.log('He recibido un cuerpo de msg:', payload.body);
+});
+
+export default socket;
+


### PR DESCRIPTION
Esta vez me he atrevido con cambios en el lado servidor y todo.

En el servidor se configura una ruta `/locations_socket` que define el web socket. Para esa ruta, se establece un socket `Web.LocationsSocket` que hace que todas las peticiones a `locations:*`sean manejadas por el canal `Web.LocationsChannel`. Ese canal acepta peticiones a `locations:all` y los mensajes de tipo (o nombre, ya por aquí me pierdo en la nomenclatura) `location_message` simplemente los reenvía a todos los clientes.

En el lado cliente (todas las rutas parten de `web/static/js`): `communication/channel.js` implementa `Channel`, que se encarga de inicializar, enviar y recibir mensajes al servidor a través del web socket definido anteriormente. Se pueden registrar listeners a este `Channel` (lo de los listeners se me está llendo de las manos, pero están quedando muy reutilizables).

Existe un `LocationListener` (objeto que escucha localizaciones, del API de geolocalización o del *simulador*, por ejemplo) que usa `Channel` para enviar las localizaciones escuchadas al servidor. Se implementa en `geolocation/listeners/send_to_server_location_listener.js`.

Por último está el concepto de *broker* (se aceptan mejores nombres), que lo que hace es registrarse como listener en el `Channel`, y envía las localizaciones enviadas por el servidor a través de `Channel` a un `LocationListener`. A este broker se le pone como `LocationListener` aquel que dibuja localizaciones en el mapa y... voilà!

El usuario activa la geolocalización, que es escuchada por `SendToServerLocationListener` y enviada al servidor. El servidor por ahora simplemente hace de eco, y lo reenvía a todos los clientes del canal. `Channel` lo recibe, se lo pasa a `MessageToLocationBroker` que se lo pasa a `MarkerLocationListener` que lo dibuja en el mapa.

Si usas varios navegadores, y activas la geolocalización en sólo uno de ellos... :tada: ¡MAGIC! :tada: 